### PR TITLE
Fix FREEBIND_RANDOM environment variable getting modified by the initialisation, breaking it for child processes

### DIFF
--- a/src/freebind.c
+++ b/src/freebind.c
@@ -47,17 +47,21 @@ void __attribute__((constructor)) initialize()
 		bind_upon_connect = 1;
 	}
 
-	env_random = getenv("FREEBIND_RANDOM");
-	if(env_random == NULL)
+	char *tenv_random = getenv("FREEBIND_RANDOM");
+	if(tenv_random == NULL)
 	{
 		return;
 	}
+
+	// Copy because strtok_r modifies the string, which would break the environment for child processes
+	env_random = safe_malloc(strlen(tenv_random) + 1);
+	strcpy(env_random, tenv_random);
 
 	single_list_t* cidr_list_ipv4 = single_list_new();
 	single_list_t* cidr_list_ipv6 = single_list_new();
 	char *token;
 	char *remaining = env_random;
-	while((token = strtok_r(remaining, ", ", &remaining)))
+	for (token = strtok_r(remaining, ", ", &remaining); token != NULL; token = strtok_r(NULL, ", ", &remaining))
 	{
 		cidr_t *cidr = safe_malloc(sizeof(*cidr));
 		if(!cidr_from_string(cidr, token))


### PR DESCRIPTION
strtok_r replaces delimiters with NUL bytes. Because getenv returns a pointer to the value in the environment, this truncates the value at the first comma or slash, effectively breaking freebind for any child process.

Also fix the incorrect usage of strtok_r: the first argument must be NULL on calls after the first.